### PR TITLE
Update webhook response object with new API changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: ruby
 rvm:
-  - 1.9.3
+  - 2.2.2
 before_install: gem install bundler -v 1.10.6

--- a/lib/cm_sms/webhook/response.rb
+++ b/lib/cm_sms/webhook/response.rb
@@ -2,58 +2,60 @@ module CmSms
   module Webhook
     class Response
 
-      ATTRIBUTE_NAMES = %w(sent received to reference statuscode errorcode errordescription)
+      ATTRIBUTE_NAMES = %w(created_s datetime_s gsm reference standarderrortext status
+      statusdescription externalstatusdescription id operator recipient srcreated gsm
+      srcreated_s statuscodestring statusissuccess time errorcode)
       
       attr_reader *ATTRIBUTE_NAMES, :attributes
       
       def initialize(attributes = {})
         @attributes = attributes
         
-        attributes.each { |attr, value| instance_variable_set("@#{attr}", value) } if attributes
+        attributes.each { |attr, value| instance_variable_set("@#{attr.downcase}", value) } if attributes
       end
       
-      def sent?
-        !sent.to_s.strip.empty?
+      def statusissuccess?
+        !statusissuccess.to_s.strip.empty?
       end
       
-      def received?
-        !received.to_s.strip.empty?
+      def datetime_s?
+        !datetime_s.to_s.strip.empty?
       end
       
-      def statuscode?
-        !statuscode.to_s.strip.empty?
+      def status?
+        !status.to_s.strip.empty?
       end
       
       def errorcode?
         !errorcode.to_s.strip.empty?
       end
       
-      def sent_at
-        Time.parse(sent) if sent?
-      end
-      
       def received_at
-        Time.parse(received) if received?
+        Time.parse(datetime_s) if datetime_s?
       end
       
       def accepted?
-        statuscode? && statuscode.to_s == '0'
+        status? && status.to_s == '0'
       end
       
       def rejected?
-        statuscode? && statuscode.to_s == '1'
+        status? && status.to_s == '1'
       end
       
       def delivered?
-        statuscode? && statuscode.to_s == '2'
+        status? && status.to_s == '2'
       end
       
       def failed?
-        statuscode? && statuscode.to_s == '3'
+        status? && status.to_s == '3'
       end
       
       def error?
         errorcode? || rejected? || failed?
+      end
+
+      def success?
+        statusissuccess? && statusissuccess.to_s.strip == '1'
       end
       
       def to_yaml

--- a/spec/cm_sms/webhook/response_spec.rb
+++ b/spec/cm_sms/webhook/response_spec.rb
@@ -4,11 +4,14 @@ require 'cm_sms/webhook/response'
 RSpec.describe CmSms::Webhook::Response do
   let(:response_params) do
     {
-      sent:       '2009-06-15T13:45:30',
-      received:   '2009-06-15T13:45:30',
-      to:         '+41 44 111 22 33',
-      reference:  'gid://app/Message/1c',
-      statuscode: 0
+      created_s:          '2009-06-15T13:45:30',
+      datetime_s:         '2009-06-15T13:45:30',
+      gsm:                '+41 44 111 22 33',
+      reference:          'gid://app/Message/1c',
+      standarderrortext:  '',
+      status:             0,
+      statusdescription:  '',
+      statusissuccess:    1
     }
   end
   
@@ -16,93 +19,57 @@ RSpec.describe CmSms::Webhook::Response do
     described_class.new(response_params)
   end
   
-  describe '#sent?' do
-    context 'when sent is given' do
-      subject { response.sent? }
+  describe '#statusissuccess?' do
+    context 'when statusissucess is given' do
+      subject { response.statusissuccess? }
       it { expect(subject).to be true }
     end
     
     context 'when sent is missing' do
-      subject { described_class.new(response_params.merge(sent: nil)) }
-      it { expect(subject.sent?).to be false }
+      subject { described_class.new(response_params.merge(statusissuccess: nil)) }
+      it { expect(subject.statusissuccess?).to be false }
     end
   end
   
-  describe '#received?' do
-    context 'when received is given' do
-      subject { response.received? }
+  describe '#status?' do
+    context 'when status is given' do
+      subject { response.status? }
       it { expect(subject).to be true }
     end
     
-    context 'when received is missing' do
-      subject { described_class.new(response_params.merge(received: nil)) }
-      it { expect(subject.received?).to be false }
-    end
-  end
-  
-  describe '#statuscode?' do
-    context 'when status code is given' do
-      subject { response.statuscode? }
-      it { expect(subject).to be true }
-    end
-    
-    context 'when status code is missing' do
-      subject { described_class.new(response_params.merge(statuscode: nil)) }
-      it { expect(subject.statuscode?).to be false }
-    end
-  end
-  
-  describe '#errorcode?' do
-    context 'when error code is missing' do
-      it { expect(response.errorcode?).to be false }
-    end
-    
-    context 'when error code is given' do
-      subject { described_class.new(response_params.merge(errocode: 1)) }
-      it { expect(subject.errorcode?).to be false }
-    end
-  end
-  
-  describe '#sent_at' do
-    context 'when sent is given' do
-      subject { response.sent_at }
-      it { expect(subject).to be_kind_of Time }
-      it { expect(subject).to eq Time.parse(response_params[:sent]) }
-    end
-    
-    context 'when sent is missing' do
-      subject { described_class.new(response_params.merge(sent: nil)) }
-      it { expect(subject.sent_at).to be_nil }
+    context 'when status is missing' do
+      subject { described_class.new(response_params.merge(status: nil)) }
+      it { expect(subject.status?).to be false }
     end
   end
   
   describe '#received_at' do
-    context 'when received is given' do
+    context 'when datetime_s is given' do
       subject { response.received_at }
       it { expect(subject).to be_kind_of Time }
-      it { expect(subject).to eq Time.parse(response_params[:received]) }
+      it { expect(subject).to eq Time.parse(response_params[:datetime_s]) }
     end
     
     context 'when received is missing' do
-      subject { described_class.new(response_params.merge(received: nil)) }
+      subject { described_class.new(response_params.merge(datetime_s: nil)) }
       it { expect(subject.received_at).to be_nil }
     end
   end
   
   describe '#accepted?' do
-    context 'when statuscode is set to 0' do
+    context 'when status is set to 0' do
       it { expect(response.accepted?).to be true } 
     end
     
     context 'when statuscode is not set to 0' do
-      subject { described_class.new(response_params.merge(statuscode: 1)) }
+      subject { described_class.new(response_params.merge(status: 1)) }
       it { expect(subject.accepted?).to be false } 
     end
   end
   
   describe '#rejected?' do
     context 'when statuscode is set to 1' do
-      subject { described_class.new(response_params.merge(statuscode: 1)) }
+      subject { described_class.new(response_params.merge(status: 1)) }
       it { expect(subject.rejected?).to be true } 
     end
     
@@ -113,7 +80,7 @@ RSpec.describe CmSms::Webhook::Response do
   
   describe '#delivered?' do
     context 'when statuscode is set to 2' do
-      subject { described_class.new(response_params.merge(statuscode: 2)) }
+      subject { described_class.new(response_params.merge(status: 2)) }
       it { expect(subject.delivered?).to be true } 
     end
     
@@ -123,12 +90,12 @@ RSpec.describe CmSms::Webhook::Response do
   end
   
   describe '#failed?' do
-    context 'when statuscode is set to 2' do
-      subject { described_class.new(response_params.merge(statuscode: 3)) }
+    context 'when statuscode is set to 3' do
+      subject { described_class.new(response_params.merge(status: 3)) }
       it { expect(subject.failed?).to be true } 
     end
     
-    context 'when statuscode is not set to 2' do
+    context 'when statuscode is not set to 3' do
       it { expect(response.failed?).to be false } 
     end
   end
@@ -140,13 +107,29 @@ RSpec.describe CmSms::Webhook::Response do
     end
     
     context 'when rejected? returns true' do
-      subject { described_class.new(response_params.merge(statuscode: 1)) }
+      subject { described_class.new(response_params.merge(status: 1)) }
       it { expect(subject.error?).to be true } 
     end
     
     context 'when failed? returns true' do
-      subject { described_class.new(response_params.merge(statuscode: 3)) }
+      subject { described_class.new(response_params.merge(status: 3)) }
       it { expect(subject.error?).to be true } 
+    end
+  end
+
+  describe '#success?' do
+    context 'when statusissuccess is set' do
+      it { expect(response.success?).to be true}
+    end
+
+    context 'when statusissuccess is missing' do
+      subject { described_class.new(response_params.merge(statusissuccess: nil)) }
+      it { expect(subject.success?).to be false}
+    end
+
+    context 'when statusissuccess is 0' do
+      subject { described_class.new(response_params.merge(statusissuccess: 0)) }
+      it{ expect(subject.success?).to be false }
     end
   end
   


### PR DESCRIPTION
The CM SMS webhook status report API has [changed](https://docs.cmtelecom.com/bulk_sms/v1.0#/status_report_webhook), therefore I have added the new fields/removed the old ones and updated the specs.