### PR TITLE
Remove runtime dependency on Phony; allow validation with either Phony or Phonelib

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,14 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in cm-sms.gemspec
 gemspec
 
-gem 'tins', '1.5.4', require: false, group: :test
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.0.0')
+  gem 'tins', '>= 1.5.4', require: false, group: :test
+else
+  gem 'public_suffix', '< 1.5.0'
+  gem 'tins', '< 1.7.0', '>= 1.5.4', require: false, group: :test
+  gem 'webmock', '<= 1.24.6', '>= 1.0.0', group: :test
+  gem 'term-ansicolor', '< 1.4.0', group: :test
+end
+
 gem 'simplecov', require: false, group: :test
 gem 'coveralls', require: false, group: :test

--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ or without bundler
 $ gem update cms-sms
 ```
 ​
+Optional Number Validation
+--------------------------
+
+Cm-Sms will look for the presence of either [Phony](https://github.com/floere/phony)
+or [Phonelib](https://github.com/daddyz/phonelib) and use one of these libraries
+to perform a basic check of receiver number. This check does not consider whether the
+number is a mobile number.
+
 Changelog
 ---------
 

--- a/cm-sms.gemspec
+++ b/cm-sms.gemspec
@@ -23,12 +23,12 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "webmock", "~> 1.0"
-  
+  spec.add_development_dependency "phony", "~> 2.12"
+  spec.add_development_dependency "phonelib", "~> 0.6"
+
   if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-    spec.add_runtime_dependency "phony", "~> 2.12"
     spec.add_runtime_dependency "builder", "~> 3.2"
   else
-    spec.add_dependency "phony", "~> 2.15"
     spec.add_dependency "builder", "~> 3.2"
   end
 end

--- a/lib/cm_sms/message.rb
+++ b/lib/cm_sms/message.rb
@@ -1,5 +1,4 @@
 require 'builder'
-require 'phony'
 require 'cm_sms/request'
 
 module CmSms
@@ -11,63 +10,69 @@ module CmSms
     class BodyTooLong < ArgumentError; end
     class ToUnplausible < ArgumentError; end
     class DCSNotNumeric < ArgumentError; end
-    
+
     attr_accessor :from, :to, :body, :dcs, :reference
-    
+
     def initialize(attributes = {})
       @from          = attributes[:from]
       @to            = attributes[:to]
       @dcs           = attributes[:dcs]
       @body          = attributes[:body]
       @reference     = attributes[:reference]
-      
+
       @product_token = CmSms.config.product_token
     end
-    
+
     def dcs_numeric?
-      true if dcs.nil? || Float(dcs) 
-    rescue 
+      true if dcs.nil? || Float(dcs)
+    rescue
       false
     end
-    
-    def receiver_plausible?      
-      receiver_present? && Phony.plausible?(to)
+
+    def receiver_plausible?
+      plausible = receiver_present?
+      if defined?(Phony) && Phony.respond_to?(:plausible?)
+        plausible &&= Phony.plausible?(to)
+      elsif defined?(Phonelib) && Phonelib.respond_to?(:valid?)
+        plausible &&= Phonelib.valid?(to)
+      end
+      plausible
     end
-    
+
     def receiver_present?
       !to.nil? && !to.empty?
     end
-    
+
     def sender_present?
       !from.nil? && !from.empty?
     end
-    
+
     def sender_length?
       sender_present? && from.length <= 11
     end
-    
+
     def body_present?
       !body.nil? && !body.empty?
     end
-      
+
     def body_correct_length?
       body_present? && body.length <= 160
     end
-    
+
     def product_token_present?
       !@product_token.nil? && !@product_token.empty?
     end
-    
+
     def request
       Request.new(to_xml)
     end
-    
+
     def deliver
       raise CmSms::Configuration::ProductTokenMissing.new("Please provide an valid product key.\nAfter signup at https://www.cmtelecom.de/, you will find one in your settings.") unless product_token_present?
-      
+
       request.perform
     end
-    
+
     def deliver!
       raise FromMissing.new('The value for the from attribute is missing.') unless sender_present?
       raise FromTooLong.new('The value for the sender attribute must contain 1..11 characters.') unless sender_length?
@@ -76,10 +81,10 @@ module CmSms
       raise BodyTooLong.new('The body of the message has a length greater than 160.') unless body_correct_length?
       raise ToUnplausible.new("The given value for the to attribute is not a plausible phone number.\nMaybe the country code is missing.") unless receiver_plausible?
       raise DCSNotNumeric.new("The given value for the dcs attribute is not a number.") unless dcs_numeric?
-      
+
       deliver
     end
-    
+
     def to_xml
       builder = Builder::XmlMarkup.new
       builder.instruct! :xml, version: '1.0'

--- a/spec/cm_sms/message_spec.rb
+++ b/spec/cm_sms/message_spec.rb
@@ -2,13 +2,13 @@ require 'spec_helper'
 require 'cm_sms/message'
 
 RSpec.describe CmSms::Message do
-  
+
   let(:message_body) { 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirood tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At v' }
-  
+
   let(:message) do
     message = described_class.new
-    message.from = 'ACME'    
-    message.to = '+41 44 111 22 33'      
+    message.from = 'ACME'
+    message.to = '+41 44 111 22 33'
     message.body = message_body
     message.reference = 'Ref:123'
     message
@@ -18,92 +18,116 @@ RSpec.describe CmSms::Message do
     context 'when dcs is provided as number' do
       it { expect(message.dcs_numeric?).to be true }
     end
-    
+
     context 'when dcs is provided not as number' do
       subject(:resource) do
-        message.dcs = 'Fuubar'        
+        message.dcs = 'Fuubar'
         message
       end
       it { expect(resource.dcs_numeric?).to be false }
     end
   end
-  
+
   describe '#receiver_plausible?' do
     context 'when a valid phone number is provided' do
       it { expect(message.receiver_plausible?).to be true }
     end
-    
-    context 'when a invalid phone number is provided' do
-      subject(:resource) do
-        message.to = 'Fuubar'        
-        message
+
+    context 'phony present' do
+      context 'when a invalid phone number is provided' do
+        subject(:resource) do
+          message.to = 'Fuubar'
+          message
+        end
+        it { expect(resource.receiver_plausible?).to be false }
       end
-      it { expect(resource.receiver_plausible?).to be false }
+    end
+
+    context 'phonelib present' do
+      before { hide_const('Phony') }
+      context 'when a invalid phone number is provided' do
+        subject(:resource) do
+          message.to = 'Fuubar'
+          message
+        end
+        it { expect(resource.receiver_plausible?).to be false }
+      end
+    end
+
+    context 'neither phony nor phonelib present' do
+      before { hide_const('Phony'); hide_const('Phonelib') }
+      context 'when a invalid phone number is provided' do
+        subject(:resource) do
+          message.to = 'Fuubar'
+          message
+        end
+        it { expect(resource.receiver_plausible?).to be true }
+      end
     end
   end
-  
+
   describe '#receiver_present?' do
     context 'when a valid phone number is provided' do
       it { expect(message.receiver_present?).to be true }
     end
-    
+
     context 'when no phone number is provided' do
       subject(:resource) do
-        message.to = nil        
+        message.to = nil
         message
       end
       it { expect(resource.receiver_present?).to be false }
     end
   end
-  
+
   describe '#sender_present?' do
     context 'when a valid from is provided' do
       it { expect(message.sender_present?).to be true }
     end
-    
+
     context 'when no from is provided' do
       subject(:resource) do
-        message.from = nil        
+        message.from = nil
         message
       end
       it { expect(resource.sender_present?).to be false }
     end
   end
-  
+
   describe '#body_present?' do
     context 'when a valid body is provided' do
       it { expect(message.body_present?).to be true }
     end
-    
+
     context 'when no body is provided' do
       subject(:resource) do
-        message.body = nil        
+        message.body = nil
         message
       end
       it { expect(resource.body_present?).to be false }
     end
   end
-  
+
   describe '#product_token_present?' do
     context 'when a valid product_token is provided' do
       before { CmSms.configure { |config| config.product_token = 'SOMETOKEN' } }
       it { expect(message.product_token_present?).to be true }
     end
-    
+
     context 'when no product_token is provided' do
       before { CmSms.configure { |config| config.product_token = nil } }
       it { expect(message.product_token_present?).to be false }
     end
   end
-  
+
   describe '#deliver' do
     context 'when product token is missing in configuration' do
       before { CmSms.configure { |config| config.product_token = nil } }
       it { expect { message.deliver }.to raise_error CmSms::Configuration::ProductTokenMissing }
     end
-    
+
     context 'when all needed attributes set' do
-      before do 
+      before do
         CmSms.configure { |config| config.product_token = 'SOMETOKEN' }
         request = instance_double(CmSms::Request)
         allow(request).to receive(:perform).and_return(true)
@@ -112,13 +136,13 @@ RSpec.describe CmSms::Message do
       it { expect(message.deliver).to be true }
     end
   end
-  
+
   describe '#deliver!' do
     context 'when product token is missing in configuration' do
       before { CmSms.configure { |config| config.product_token = nil } }
       it { expect { message.deliver! }.to raise_error CmSms::Configuration::ProductTokenMissing }
     end
-    
+
     context 'when product token is given' do
       before { CmSms.configure { |config| config.product_token = 'SOMETOKEN' } }
       context 'when receiver is missing' do
@@ -128,7 +152,7 @@ RSpec.describe CmSms::Message do
         end
         it { expect { resource.deliver! }.to raise_error CmSms::Message::ToMissing }
       end
-    
+
       context 'when sender is missing' do
         subject(:resource) do
           message.from = nil
@@ -136,7 +160,7 @@ RSpec.describe CmSms::Message do
         end
         it { expect { resource.deliver! }.to raise_error CmSms::Message::FromMissing }
       end
-    
+
       context 'when body is missing' do
         subject(:resource) do
           message.body = nil
@@ -144,7 +168,7 @@ RSpec.describe CmSms::Message do
         end
         it { expect { resource.deliver! }.to raise_error CmSms::Message::BodyMissing }
       end
-    
+
       context 'when body is to long' do
         subject(:resource) do
           message.body = [message.body, message.body].join # 2 x 160 signs
@@ -152,7 +176,7 @@ RSpec.describe CmSms::Message do
         end
         it { expect { resource.deliver! }.to raise_error CmSms::Message::BodyTooLong }
       end
-    
+
       context 'when to is not plausibe' do
         subject(:resource) do
           message.to = 'fuubar'
@@ -160,7 +184,7 @@ RSpec.describe CmSms::Message do
         end
         it { expect { resource.deliver! }.to raise_error CmSms::Message::ToUnplausible }
       end
-    
+
       context 'when dcs is not a number' do
         subject(:resource) do
           message.dcs = 'fuubar'
@@ -169,9 +193,9 @@ RSpec.describe CmSms::Message do
         it { expect { resource.deliver! }.to raise_error CmSms::Message::DCSNotNumeric }
       end
     end
-    
+
     context 'when all needed attributes set' do
-      before do 
+      before do
         CmSms.configure { |config| config.product_token = 'SOMETOKEN' }
         request = instance_double(CmSms::Request)
         allow(request).to receive(:perform).and_return(true)
@@ -180,19 +204,19 @@ RSpec.describe CmSms::Message do
       it { expect(message.deliver).to be true }
     end
   end
-  
+
   describe '#request' do
     it { expect(message.request).to be_kind_of(CmSms::Request) }
   end
-  
+
   describe '#to_xml' do
     before { CmSms.configure { |config| config.product_token = 'SOMETOKEN' } }
-    
+
     context 'when all attributes set' do
       let(:xml_body) { '<?xml version="1.0" encoding="UTF-8"?><MESSAGES><AUTHENTICATION><PRODUCTTOKEN>SOMETOKEN</PRODUCTTOKEN></AUTHENTICATION><MSG><FROM>ACME</FROM><TO>+41 44 111 22 33</TO><BODY>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirood tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At v</BODY><REFERENCE>Ref:123</REFERENCE></MSG></MESSAGES>' }
       it { expect(message.to_xml).to eq xml_body }
-    end    
-    
+    end
+
     context 'when reference is missing' do
       subject(:resource) do
         message.reference = nil

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ SimpleCov.start
 Bundler.setup
 
 require 'phony'
+require 'phonelib'
 require 'builder'
 require 'cm-sms'
 


### PR DESCRIPTION
My project uses Phonelib rather than Phony and I don't want to be forced to include Phony (which is relatively heavy) when I include CmSMS.

I've also included some whitespace fixes here.
